### PR TITLE
Fix comment link, and commit message format

### DIFF
--- a/src/main/java/org/bf2/arch/bot/CreateDraftRecordFlow.java
+++ b/src/main/java/org/bf2/arch/bot/CreateDraftRecordFlow.java
@@ -165,6 +165,8 @@ public class CreateDraftRecordFlow {
             // Merge it
             pr.merge(commitMessage, null, GHPullRequest.MergeMethod.REBASE);
 
+            // TODO delete PR source branch after merge
+
             // Comment on the issue with instructions
             issue.comment(String.format(
                     "Closing following creation of [%s](%s)\n" +
@@ -183,7 +185,7 @@ public class CreateDraftRecordFlow {
 
     private static String githubFileLink(GHRepository repo, RecordId record) {
         return MessageFormat.format("{0}/blob/{1}/{2}",
-                repo.getHomepage(), repo.getDefaultBranch(), record.repoPath());
+                repo.getHtmlUrl(), repo.getDefaultBranch(), record.repoPath());
     }
 
     @NotNull

--- a/src/main/java/org/bf2/arch/bot/CreateDraftRecordFlow.java
+++ b/src/main/java/org/bf2/arch/bot/CreateDraftRecordFlow.java
@@ -69,7 +69,7 @@ public class CreateDraftRecordFlow {
 
 
     /**
-     * Creates a PR for a Draft ADR when an issue comment has {@code /create-adr} (or ap, or padr),
+     * Creates a PR for a Draft ADR when an issue comment has {@code /create adr} (or ap, or padr),
      * or {@code /supersede adr 123}.
      * @param commentPayload The payload
      * @param config The config
@@ -156,7 +156,7 @@ public class CreateDraftRecordFlow {
                 tree.add(supersededRecord.repoPath(), supersededPage.toContentString(), false);
             }
 
-            var commitMessage = String.format("%s: Create draft\nFixes #%d", draftRecord, issue.getNumber());
+            var commitMessage = String.format("%s: Create draft\n\nFixes #%d", draftRecord, issue.getNumber());
             var branchRef = createCommit(draftRecord, repo, defaultBranchSha, commitMessage, tree.create());
 
             // Open a PR


### PR DESCRIPTION
The `repo.getHomepage()` returns the website configured in the repository details, so you can see the link behind the .adoc file path in https://github.com/bf2fc6cc711aee1a0c2a/architecture/issues/87#issuecomment-1408828786 points to that site rather than to the corresponding file page on GitHub.

It seems like `repo.getHtmlUrl()` is the best choice. The difference can be seen in my test repo here: https://github.com/grdryn/architecture/issues/8#issuecomment-1411242874