### PR TITLE
Limit search to one repo in StalledDiscussionFlow

### DIFF
--- a/.env
+++ b/.env
@@ -9,6 +9,11 @@
 ## and click on Configure for the app, then get it from the URL
 bot.installation.id=
 
+## The repository path, in the form <user|org>/<repo>
+## This is needed to limit search in StalledDiscussionFlow, and there
+## doesn't seem to be an easy way to get it from the GitHub client
+repository.path=
+
 ## Flags to enable/disable specific features of the bot
 bot.enable.stalled-discussion=false
 bot.enable.pr-review=false


### PR DESCRIPTION
Before this change, trying to test this flow against a fork would lead to the initial search finding results in my fork + the bf2 repo + Tom's repo. Then when it would try to add a label to a PR anywhere other than my fork, it would throw an exception.

There doesn't seem to be an easy way to figure out which repo the app installation is for from the client, so making it a config property seems the most straightforward.